### PR TITLE
Empty assetsToCache array

### DIFF
--- a/ui/service-worker.js
+++ b/ui/service-worker.js
@@ -1,10 +1,5 @@
 const CACHE_NAME = 'sky-cache-v1'
-const assetsToCache = [
-  './src/style/hollow.css',
-  './src/style/spine.css',
-  './src/style/feather.css',
-  './src/style/wind.css',
-]
+const assetsToCache = []
 
 // Install the service worker
 self.addEventListener('install', event => {


### PR DESCRIPTION
Cacheing other files has caused issues with CSS previously; hopefully this prevents a bug where content would be styled with outdated CSS but I've not confirmed whether this cache was the cause. No harm in removing it anyway.