### PR TITLE
 Path Bar Overlay and Ctrl+K shortcut

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,9 @@ function App() {
     addWindow,
     delWindow,
     setMaxWindow,
+    setPathBarView,
+    removePathBarView,
+    inPathBarView,
     updateWindowPath,
     setActiveWindowID,
   } = useWindowStore()
@@ -174,16 +177,19 @@ function App() {
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
         console.log('Pressed CTRL+K')
+
         event.preventDefault()
 
-        if (activeWindowID !== null && activeWindowID > 1 && maxWindow === 0) {
+        if (activeWindowID !== null) {
           const path = windowMap.get(activeWindowID) ?? null
 
-          if (path !== null) {
-            setMaxWindow(activeWindowID)
+          if (path !== null && path !== '') {
+            if (inPathBarView(activeWindowID)) {
+              removePathBarView(activeWindowID)
+            } else {
+              setPathBarView(activeWindowID)
+            }
           }
-        } else if (maxWindow !== 0) {
-          setMaxWindow(0)
         }
       }
     }
@@ -232,7 +238,7 @@ function App() {
         {maxWindow !== 0 && (
           <div
             className="wf hf absolute p3"
-            style={{ zIndex: 100, opacity: '98%'}}
+            style={{ zIndex: 100, opacity: '98%' }}
           >
             <Window
               id={maxWindow}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,9 +17,7 @@ function App() {
     addWindow,
     delWindow,
     setMaxWindow,
-    setPathBarView,
-    removePathBarView,
-    inPathBarView,
+    togglePathBarView,
     updateWindowPath,
     setActiveWindowID,
   } = useWindowStore()
@@ -184,11 +182,7 @@ function App() {
           const path = windowMap.get(activeWindowID) ?? null
 
           if (path !== null && path !== '') {
-            if (inPathBarView(activeWindowID)) {
-              removePathBarView(activeWindowID)
-            } else {
-              setPathBarView(activeWindowID)
-            }
+            togglePathBarView(activeWindowID)
           }
         }
       }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -171,6 +171,21 @@ function App() {
           setMaxWindow(0)
         }
       }
+
+      if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+        console.log('Pressed CTRL+K')
+        event.preventDefault()
+
+        if (activeWindowID !== null && activeWindowID > 1 && maxWindow === 0) {
+          const path = windowMap.get(activeWindowID) ?? null
+
+          if (path !== null) {
+            setMaxWindow(activeWindowID)
+          }
+        } else if (maxWindow !== 0) {
+          setMaxWindow(0)
+        }
+      }
     }
 
     const handleKeyUp = (event: KeyboardEvent) => {
@@ -217,7 +232,7 @@ function App() {
         {maxWindow !== 0 && (
           <div
             className="wf hf absolute p3"
-            style={{ zIndex: 100, opacity: '98%' }}
+            style={{ zIndex: 100, opacity: '98%'}}
           >
             <Window
               id={maxWindow}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -136,7 +136,11 @@ function App() {
       }
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'n') {
-        console.log('Pressed CTRL+N')
+        if(event.metaKey){
+          console.log('Pressed CMD+n')
+        }else{
+          console.log('Pressed CTRL+n')
+        }
         event.preventDefault()
 
         if (activeWindowID !== null && maxWindow === 0) {
@@ -145,7 +149,11 @@ function App() {
       }
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'w') {
-        console.log('Pressed CTRL+W')
+        if(event.metaKey){
+          console.log('Pressed CMD+w')
+        }else{
+          console.log('Pressed CTRL+w')
+        }
         event.preventDefault()
 
         if (activeWindowID !== null && maxWindow === 0) {
@@ -159,7 +167,11 @@ function App() {
       }
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'm') {
-        console.log('Pressed CTRL+M')
+        if(event.metaKey){
+          console.log('Pressed CMD+m')
+        }else{
+          console.log('Pressed CTRL+m')
+        }
         event.preventDefault()
 
         if (activeWindowID !== null && activeWindowID > 1 && maxWindow === 0) {
@@ -174,7 +186,11 @@ function App() {
       }
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
-        console.log('Pressed CTRL+K')
+        if(event.metaKey){
+          console.log('Pressed CMD+k')
+        }else{
+          console.log('Pressed CTRL+k')
+        }
 
         event.preventDefault()
 

--- a/ui/src/components/PathBar.tsx
+++ b/ui/src/components/PathBar.tsx
@@ -10,7 +10,8 @@ export default function PathBar({
   path: string | null
 }) {
   const [inputValue, setInputValue] = useState('')
-  const { updateWindowPath } = useWindowStore()
+  const { updateWindowPath, inPathBarView, removePathBarView } =
+    useWindowStore()
 
   useEffect(() => {
     setInputValue(path || '')
@@ -47,8 +48,11 @@ export default function PathBar({
   // TODO if first path segment is azimuth point, convert to @p
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-
     if (isValidPath(inputValue)) {
+      if (inPathBarView(id)) {
+        removePathBarView(id)
+      }
+
       updateWindowPath(id, inputValue)
     }
   }

--- a/ui/src/components/PathBar.tsx
+++ b/ui/src/components/PathBar.tsx
@@ -10,7 +10,7 @@ export default function PathBar({
   path: string | null
 }) {
   const [inputValue, setInputValue] = useState('')
-  const { updateWindowPath, inPathBarView, removePathBarView } =
+  const { updateWindowPath, inPathBarView, togglePathBarView } =
     useWindowStore()
 
   useEffect(() => {
@@ -50,7 +50,7 @@ export default function PathBar({
     e.preventDefault()
     if (isValidPath(inputValue)) {
       if (inPathBarView(id)) {
-        removePathBarView(id)
+        togglePathBarView(id)
       }
 
       updateWindowPath(id, inputValue)

--- a/ui/src/components/PathBar.tsx
+++ b/ui/src/components/PathBar.tsx
@@ -10,7 +10,7 @@ export default function PathBar({
   path: string | null
 }) {
   const [inputValue, setInputValue] = useState('')
-  const { updateWindowPath, inPathBarView, togglePathBarView } =
+  const { pathBarView, updateWindowPath, togglePathBarView } =
     useWindowStore()
 
   useEffect(() => {
@@ -49,7 +49,7 @@ export default function PathBar({
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
     if (isValidPath(inputValue)) {
-      if (inPathBarView(id)) {
+      if (pathBarView.includes(id)) {
         togglePathBarView(id)
       }
 

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -332,7 +332,7 @@ export default function Window({
             <div
               className="absolute b1 br1 bd1"
               style={{
-                zIndex: 99,
+                zIndex: 90,
                 opacity: '90%',
                 width: 'calc(100% - 10px)',
                 height: 'calc(100% - 10px)',

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -50,6 +50,7 @@ export default function Window({
   ])
   const {
     maxWindow,
+    inPathBarView,
     setMaxWindow,
     setActiveWindowID,
     setActiveWindowPath,
@@ -320,22 +321,32 @@ export default function Window({
     <Allotment>
       <Allotment.Pane visible key={id} className="wf hf fr">
         <div
-          className="hf wf fc ac jc relative"
-          style={{ padding: '5px', position: 'relative' }}
+          className="wf hf fc ac jc relative"
+          style={{
+            padding: '5px',
+            boxSizing: 'border-box',
+          }}
           onMouseEnter={handleWindowMouseEnter}
         >
-          <div
-            className="wf hf absolute p3"
-            style={{ zIndex: 99, opacity: '90%', background: 'var(--b1)'}}
-          >
-            <div className="hf wf p2 fc ac jc">
-              <PathBar id={id} path={path} />
+          {inPathBarView(id) && (
+            <div
+              className="absolute b1 br1 bd1"
+              style={{
+                zIndex: 99,
+                opacity: '90%',
+                width: 'calc(100% - 10px)',
+                height: 'calc(100% - 10px)',
+              }}
+            >
+              <div className="hf wf p2 fc ac jc">
+                <PathBar id={id} path={path} />
+              </div>
             </div>
-          </div>
+          )}
           <div
             id={id.toString()}
             draggable={dragWindow === id ? true : false}
-            className="hf wf container fc as js b1 br1 bd1"
+            className="wf hf container fc as js b1 br1 bd1"
             onDragStart={e => handleDragStart(e, id)}
             onDrop={(e: React.DragEvent<HTMLDivElement>) => handleDrop(e, id)}
             onDragEnd={handleDragEnd}

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -320,10 +320,18 @@ export default function Window({
     <Allotment>
       <Allotment.Pane visible key={id} className="wf hf fr">
         <div
-          className="hf wf fc ac jc"
+          className="hf wf fc ac jc relative"
           style={{ padding: '5px', position: 'relative' }}
           onMouseEnter={handleWindowMouseEnter}
         >
+          <div
+            className="wf hf absolute p3"
+            style={{ zIndex: 99, opacity: '90%', background: 'var(--b1)'}}
+          >
+            <div className="hf wf p2 fc ac jc">
+              <PathBar id={id} path={path} />
+            </div>
+          </div>
           <div
             id={id.toString()}
             draggable={dragWindow === id ? true : false}

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -50,7 +50,7 @@ export default function Window({
   ])
   const {
     maxWindow,
-    inPathBarView,
+    pathBarView,
     setMaxWindow,
     setActiveWindowID,
     setActiveWindowPath,
@@ -328,7 +328,7 @@ export default function Window({
           }}
           onMouseEnter={handleWindowMouseEnter}
         >
-          {inPathBarView(id) && (
+          {pathBarView.includes(id) && (
             <div
               className="absolute b1 br1 bd1"
               style={{

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -159,7 +159,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // maximise a window
   setMaxWindow: (id: number) => set({ maxWindow: id }),
 
-  // add a window id to the pathBarView array
+  // add window id to the pathBarView array
   setPathBarView: (id: number) => {
     const windowArray = get().pathBarView
     set({
@@ -168,7 +168,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
     console.log('pathBarView after update:', [...windowArray, id])
   },
 
-  // add a window id from the pathBarView array
+  // remove window id from the pathBarView array
   removePathBarView: (id: number) => {
     const windowArray = get().pathBarView
     const updatedPathBarView = windowArray.filter(item => item !== id)
@@ -177,7 +177,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
     })
   },
 
-  //  returns boolean if window id in pathBarView array
+  //  return boolean if window id in pathBarView array
   inPathBarView: (id: number) => {
     const pathBarView = get().pathBarView
     return pathBarView.includes(id)

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -8,6 +8,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // init default state values
   windowMap: defaultMap,
   maxWindow: 0,
+  pathBarView: [],
   activeWindowID: 1,
   activeWindowPath: defaultPath,
 
@@ -157,6 +158,30 @@ const useWindowStore = create<WindowState>((set, get) => ({
 
   // maximise a window
   setMaxWindow: (id: number) => set({ maxWindow: id }),
+
+  // add a window id to the pathBarView array
+  setPathBarView: (id: number) => {
+    const windowArray = get().pathBarView
+    set({
+      pathBarView: [...windowArray, id],
+    })
+    console.log('pathBarView after update:', [...windowArray, id])
+  },
+
+  // add a window id from the pathBarView array
+  removePathBarView: (id: number) => {
+    const windowArray = get().pathBarView
+    const updatedPathBarView = windowArray.filter(item => item !== id)
+    set({
+      pathBarView: updatedPathBarView,
+    })
+  },
+
+  //  returns boolean if window id in pathBarView array
+  inPathBarView: (id: number) => {
+    const pathBarView = get().pathBarView
+    return pathBarView.includes(id)
+  },
 
   // track active window
   setActiveWindowID: (id: number | null) => set({ activeWindowID: id }),

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -162,10 +162,12 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // add window id to the pathBarView array
   setPathBarView: (id: number) => {
     const windowArray = get().pathBarView
-    set({
-      pathBarView: [...windowArray, id],
-    })
-    console.log('pathBarView after update:', [...windowArray, id])
+    const inPathBarView = get().inPathBarView(id)
+    if (!inPathBarView) {
+      set({
+        pathBarView: [...windowArray, id],
+      })
+    }
   },
 
   // remove window id from the pathBarView array

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -162,8 +162,8 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // toggle window id in and out of pathBarView array
   togglePathBarView: (id: number) => {
     const windowArray = get().pathBarView
-    const inPathBarView = get().inPathBarView(id)
-    if (!inPathBarView) {
+    const pathBarView = get().pathBarView
+    if (!pathBarView.includes(id)) {
       // add window id to the pathBarView array
       set({
         pathBarView: [...windowArray, id],
@@ -175,12 +175,6 @@ const useWindowStore = create<WindowState>((set, get) => ({
         pathBarView: updatedPathBarView,
       })
     }
-  },
-
-  //  return boolean if window id in pathBarView array
-  inPathBarView: (id: number) => {
-    const pathBarView = get().pathBarView
-    return pathBarView.includes(id)
   },
 
   // track active window

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -159,24 +159,22 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // maximise a window
   setMaxWindow: (id: number) => set({ maxWindow: id }),
 
-  // add window id to the pathBarView array
-  setPathBarView: (id: number) => {
+  // toggle window id in and out of pathBarView array
+  togglePathBarView: (id: number) => {
     const windowArray = get().pathBarView
     const inPathBarView = get().inPathBarView(id)
     if (!inPathBarView) {
+      // add window id to the pathBarView array
       set({
         pathBarView: [...windowArray, id],
       })
+    }else{
+      // remove window id from the pathBarView array
+      const updatedPathBarView = windowArray.filter(item => item !== id)
+      set({
+        pathBarView: updatedPathBarView,
+      })
     }
-  },
-
-  // remove window id from the pathBarView array
-  removePathBarView: (id: number) => {
-    const windowArray = get().pathBarView
-    const updatedPathBarView = windowArray.filter(item => item !== id)
-    set({
-      pathBarView: updatedPathBarView,
-    })
   },
 
   //  return boolean if window id in pathBarView array

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -9,8 +9,7 @@ export default interface WindowState {
   clearWindows: () => void
   updateWindowPath: (id: number, path: string) => void
   setMaxWindow: (id: number) => void
-  setPathBarView: (id: number) => void
-  removePathBarView: (id: number) => void
+  togglePathBarView: (id: number) => void
   inPathBarView: (id: number) => boolean
   setActiveWindowID: (id: number | null) => void
   setActiveWindowPath: (path: string | null) => void

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -10,7 +10,6 @@ export default interface WindowState {
   updateWindowPath: (id: number, path: string) => void
   setMaxWindow: (id: number) => void
   togglePathBarView: (id: number) => void
-  inPathBarView: (id: number) => boolean
   setActiveWindowID: (id: number | null) => void
   setActiveWindowPath: (path: string | null) => void
 }

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -1,6 +1,7 @@
 export default interface WindowState {
   windowMap: Map<number, string | null>
   maxWindow: number
+  pathBarView: Array<number>
   activeWindowID: number | null
   activeWindowPath: string | null
   addWindow: (parentId: number, path: string) => void
@@ -8,6 +9,9 @@ export default interface WindowState {
   clearWindows: () => void
   updateWindowPath: (id: number, path: string) => void
   setMaxWindow: (id: number) => void
+  setPathBarView: (id: number) => void
+  removePathBarView: (id: number) => void
+  inPathBarView: (id: number) => boolean
   setActiveWindowID: (id: number | null) => void
   setActiveWindowPath: (path: string | null) => void
 }


### PR DESCRIPTION
Closes #77 
Implemented `Ctrl+K` or `Cmd+K` keyboard shortcut, that toggles visibility of path bar overlay.
On submitting path through input form, path bar view will be closed and window will update to newly provided path.