### PR TITLE
Amend path and ID types to be non-nullable

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
 
         event.dataTransfer.setDragImage(dragImage, 0, 0)
 
-        event.target.addEventListener('dragend', function () {
+        event.target.addEventListener('dragend', function() {
           const eventIframe = (event.target as Element).querySelector(
             'iframe'
           ) as HTMLIFrameElement
@@ -91,7 +91,7 @@ function App() {
 
   function handleSwap() {
     if (windowMap.size > 1 && maxWindow === 0) {
-      setDragWindow(activeWindowID ?? 0)
+      setDragWindow(activeWindowID)
       const containers = document.querySelectorAll('.container')
       containers.forEach(container => {
         //  create overlay for each window
@@ -121,7 +121,7 @@ function App() {
   // listen for keydown events
   useEffect(() => {
     console.log(
-      `path: ${activeWindowID ? windowMap.get(activeWindowID) : 'null'}`
+      `path: ${windowMap.get(activeWindowID)}`
     )
     console.log(`activeWindowID: ${activeWindowID}`)
     console.log(`maxWindow: ${maxWindow}`)
@@ -139,7 +139,7 @@ function App() {
         }
         event.preventDefault()
 
-        if (activeWindowID !== null && maxWindow === 0) {
+        if (maxWindow === 0) {
           addWindow(activeWindowID, '')
         }
       }
@@ -152,7 +152,7 @@ function App() {
         }
         event.preventDefault()
 
-        if (activeWindowID !== null && maxWindow === 0) {
+        if (maxWindow === 0) {
           delWindow(activeWindowID)
         }
       }
@@ -165,7 +165,7 @@ function App() {
         }
         event.preventDefault()
 
-        if (activeWindowID !== null && activeWindowID > 1 && maxWindow === 0) {
+        if (activeWindowID > 1 && maxWindow === 0) {
           const path = windowMap.get(activeWindowID) ?? null
 
           if (path !== null) {
@@ -202,10 +202,8 @@ function App() {
       }
     }
 
-    if (activeWindowID !== null) {
-      window.addEventListener('keydown', handleKeyDown, { capture: true })
-      window.addEventListener('keyup', handleKeyUp, { capture: true })
-    }
+    window.addEventListener('keydown', handleKeyDown, { capture: true })
+    window.addEventListener('keyup', handleKeyUp, { capture: true })
 
     // Cleanup event listener when the component is unmounted
     return () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
 
         event.dataTransfer.setDragImage(dragImage, 0, 0)
 
-        event.target.addEventListener('dragend', function () {
+        event.target.addEventListener('dragend', function() {
           const eventIframe = (event.target as Element).querySelector(
             'iframe'
           ) as HTMLIFrameElement
@@ -153,12 +153,8 @@ function App() {
         event.preventDefault()
 
         if (activeWindowID !== null && maxWindow === 0) {
-          if (activeWindowID === 1) {
-            updateWindowPath(activeWindowID, '')
-          } else {
-            delWindow(activeWindowID)
-            setActiveWindowID(null)
-          }
+          delWindow(activeWindowID)
+          setActiveWindowID(null)
         }
       }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
 
         event.dataTransfer.setDragImage(dragImage, 0, 0)
 
-        event.target.addEventListener('dragend', function() {
+        event.target.addEventListener('dragend', function () {
           const eventIframe = (event.target as Element).querySelector(
             'iframe'
           ) as HTMLIFrameElement
@@ -154,7 +154,6 @@ function App() {
 
         if (activeWindowID !== null && maxWindow === 0) {
           delWindow(activeWindowID)
-          setActiveWindowID(null)
         }
       }
 

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -12,7 +12,7 @@ import TextPlain from './renderers/TextPlain'
 
 export interface WindowProps {
   id: number
-  path: string | null
+  path: string 
   handleDrop: (event: React.DragEvent<HTMLDivElement>, id: number) => void
   handleDragStart: (event: React.DragEvent, id: number) => void
   dragWindow: number
@@ -58,7 +58,7 @@ export default function Window({
 
   function handleWindowMouseEnter() {
     setActiveWindowID(id)
-    setActiveWindowPath(path ?? `${window.ship || window.urbitID}/home`)
+    setActiveWindowPath(path)
   }
 
   const notRecognizedContent = (

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -58,7 +58,7 @@ export default function Window({
 
   function handleWindowMouseEnter() {
     setActiveWindowID(id)
-    setActiveWindowPath(path)
+    setActiveWindowPath(path ?? `${window.ship || window.urbitID}/home`)
   }
 
   const notRecognizedContent = (

--- a/ui/src/components/WindowContainer.tsx
+++ b/ui/src/components/WindowContainer.tsx
@@ -2,9 +2,10 @@ import { Allotment } from 'allotment'
 import { useRef, useCallback } from 'react'
 import Window from './Window.tsx'
 import useWindowStore from '../state/useWindowStore'
+import { defaultPath } from '../state/useWindowStore'
 
 export interface WindowContainerProps {
-  map: Map<number, string | null>
+  map: Map<number, string> | undefined
   id: number
   isVertical: boolean
   handleDrop: (event: React.DragEvent<HTMLDivElement>, id: number) => void
@@ -24,7 +25,8 @@ export default function WindowContainer({
   const lastChange = useRef<number[]>([])
 
   const childId = id * 2
-  const hasChildren = map ? map.get(id) === null : false
+  // A window has children if it's being used as a container
+  const hasChildren = map.has(childId) || map.has(childId + 1)
 
   // TODO should get size info from Window and use
   // that for the preferredSize
@@ -67,7 +69,8 @@ export default function WindowContainer({
     [map, hasChildren, childId, delWindow]
   )
 
-  if (!map) return <></>
+  // We know map must exist after this check
+  if (!map) return null
 
   return (
     <Allotment
@@ -82,7 +85,7 @@ export default function WindowContainer({
         // return a window
         <Window
           id={id}
-          path={map.get(id) ?? null}
+          path={map.get(id) ?? defaultPath}
           handleDrop={handleDrop}
           handleDragStart={handleDragStart}
           dragWindow={dragWindow}

--- a/ui/src/components/WindowContainer.tsx
+++ b/ui/src/components/WindowContainer.tsx
@@ -2,7 +2,6 @@ import { Allotment } from 'allotment'
 import { useRef, useCallback } from 'react'
 import Window from './Window.tsx'
 import useWindowStore from '../state/useWindowStore'
-import { defaultPath } from '../state/useWindowStore'
 
 export interface WindowContainerProps {
   map: Map<number, string> | undefined
@@ -85,7 +84,7 @@ export default function WindowContainer({
         // return a window
         <Window
           id={id}
-          path={map.get(id) ?? defaultPath}
+          path={map.get(id) ?? `${window.ship || window.urbitID}/home`}
           handleDrop={handleDrop}
           handleDragStart={handleDragStart}
           dragWindow={dragWindow}

--- a/ui/src/components/WindowContainer.tsx
+++ b/ui/src/components/WindowContainer.tsx
@@ -25,7 +25,7 @@ export default function WindowContainer({
 
   const childId = id * 2
   // A window has children if it's being used as a container
-  const hasChildren = map.has(childId) || map.has(childId + 1)
+  const hasChildren = map?.has(childId) || map?.has(childId + 1)
 
   // TODO should get size info from Window and use
   // that for the preferredSize
@@ -50,11 +50,11 @@ export default function WindowContainer({
         const index = sizes.findIndex(num => num === 0)
 
         if (index !== -1 && hasChildren) {
-          if (index === 0 && map.has(childId)) {
+          if (index === 0 && map?.has(childId)) {
             setTimeout(() => {
               delWindow(childId)
             }, 1000)
-          } else if (index === 1 && map.has(childId + 1)) {
+          } else if (index === 1 && map?.has(childId + 1)) {
             setTimeout(() => {
               delWindow(childId + 1)
             }, 1000)
@@ -69,7 +69,7 @@ export default function WindowContainer({
   )
 
   // We know map must exist after this check
-  if (!map) return null
+  if (!map) return <></>
 
   return (
     <Allotment

--- a/ui/src/components/renderers/FileCSS.tsx
+++ b/ui/src/components/renderers/FileCSS.tsx
@@ -34,10 +34,7 @@ export default function FileCSS({ css }: FileCSSProps): JSX.Element {
   const [isEdited, setIsEdited] = useState(false)
   const { activeWindowPath } = useWindowStore()
 
-  // TODO path should never be null
-  const pathArray = activeWindowPath
-    ? activeWindowPath.split('/')
-    : `${window.ship || window.urbitID}/home`.split('/')
+  const pathArray = activeWindowPath.split('/')
   const ship = pathArray[0]
   const endpoint = pathArray.slice(1).join('/')
   const tempPath = `${ship}/sys/tmp/${endpoint}`
@@ -58,8 +55,7 @@ export default function FileCSS({ css }: FileCSSProps): JSX.Element {
             setEditorContent(content)
 
             // check if editor content differs from published content
-            // TODO path should never be null
-            const publishedRes = await get(activeWindowPath || '~sampel/home')
+            const publishedRes = await get(activeWindowPath)
 
             if (publishedRes) {
               if (publishedRes.status !== 404) {

--- a/ui/src/components/renderers/FileHTML.tsx
+++ b/ui/src/components/renderers/FileHTML.tsx
@@ -45,10 +45,7 @@ export default function FileHTML({ html }: FileHTMLProps): JSX.Element {
   )
   const { activeWindowPath } = useWindowStore()
 
-  // TODO path should never be null
-  const pathArray = activeWindowPath
-    ? activeWindowPath.split('/')
-    : `${window.ship || window.urbitID}/home`.split('/')
+  const pathArray = activeWindowPath.split('/')
   const ship = pathArray[0]
   const endpoint = pathArray.slice(1).join('/')
   const tempPath = `${ship}/sys/tmp/${endpoint}`
@@ -104,7 +101,7 @@ export default function FileHTML({ html }: FileHTMLProps): JSX.Element {
             setEditorContent(content)
             // check if editor content differs from published content
             // TODO path should never be null
-            const publishedRes = await get(activeWindowPath || '~sampel/home')
+            const publishedRes = await get(activeWindowPath)
 
             if (publishedRes) {
               if (publishedRes.status !== 404) {

--- a/ui/src/components/renderers/FileHTML.tsx
+++ b/ui/src/components/renderers/FileHTML.tsx
@@ -100,7 +100,6 @@ export default function FileHTML({ html }: FileHTMLProps): JSX.Element {
             const content = await tempRes.text()
             setEditorContent(content)
             // check if editor content differs from published content
-            // TODO path should never be null
             const publishedRes = await get(activeWindowPath)
 
             if (publishedRes) {

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import WindowState from './windowState'
 
-export const defaultPath = '~sampel/home'
+const defaultPath= `~sampel/home`
 const defaultMap = new Map<number, string>([[1, defaultPath]])
 
 const useWindowStore = create<WindowState>((set, get) => ({
@@ -17,7 +17,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
     const windowMap = get().windowMap
     const parentPath = windowMap.get(parentId) ?? defaultPath
 
-    // When splitting a window, the parent becomes a container window with the default path
+    // When splitting a window, the parent becomes a container window
     windowMap.set(parentId * 2, parentPath)
     windowMap.set(parentId * 2 + 1, path)
     windowMap.set(parentId, defaultPath)

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -31,6 +31,11 @@ const useWindowStore = create<WindowState>((set, get) => ({
   delWindow: (id: number) => {
     const windowMap = get().windowMap
 
+    // If this is the last window (defaultMap), don't allow deletion
+    if (windowMap.size === 1 && windowMap.has(1)) {
+      return
+    }
+
     windowMap.delete(id)
 
     function isEven(num: number): boolean {
@@ -145,6 +150,13 @@ const useWindowStore = create<WindowState>((set, get) => ({
       set({ windowMap: defaultMap })
     } else {
       handleDelete(windowMap, id)
+
+      // If no windows are left after deletion, reset to defaultMap
+      if (windowMap.size === 0) {
+        set({ windowMap: defaultMap })
+      } else {
+        set({ windowMap })
+      }
     }
   },
 

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -177,7 +177,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
   },
 
   // track active window
-  setActiveWindowID: (id: number | null) => set({ activeWindowID: id }),
+  setActiveWindowID: (id: number) => set({ activeWindowID: id }),
 
   // track active window's path
   setActiveWindowPath: (path: string) => set({ activeWindowPath: path }),

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import WindowState from './windowState'
 
-const defaultPath = `~sampel/home`
+const defaultPath = '~sampel/home'
 const defaultMap = new Map<number, string>([[1, defaultPath]])
 
 const useWindowStore = create<WindowState>((set, get) => ({

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -148,9 +148,6 @@ const useWindowStore = create<WindowState>((set, get) => ({
     }
   },
 
-  // remove all nodes, open the default window
-  clearWindows: () => set({ windowMap: defaultMap }),
-
   // update a window's path
   updateWindowPath: (id: number, path: string) => {
     const windowMap = get().windowMap

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand'
 import WindowState from './windowState'
 
-const defaultPath = '~sampel/home'
-const defaultMap = new Map<number, string | null>([[1, defaultPath]])
+export const defaultPath = '~sampel/home'
+const defaultMap = new Map<number, string>([[1, defaultPath]])
 
 const useWindowStore = create<WindowState>((set, get) => ({
   // init default state values
@@ -15,11 +15,12 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // add a new window to the tree
   addWindow: (parentId: number, path: string) => {
     const windowMap = get().windowMap
-    const parentPath = windowMap.get(parentId) ?? ''
+    const parentPath = windowMap.get(parentId) ?? defaultPath
 
+    // When splitting a window, the parent becomes a container window with the default path
     windowMap.set(parentId * 2, parentPath)
     windowMap.set(parentId * 2 + 1, path)
-    windowMap.set(parentId, null)
+    windowMap.set(parentId, defaultPath)
 
     set({ windowMap })
   },
@@ -147,13 +148,9 @@ const useWindowStore = create<WindowState>((set, get) => ({
   // update a window's path
   updateWindowPath: (id: number, path: string) => {
     const windowMap = get().windowMap
-
-    if (windowMap.has(id)) {
-      windowMap.set(id, path)
-      set({ windowMap: windowMap })
-    } else {
-      set({ windowMap: windowMap })
-    }
+    // If the window doesn't exist, create it with the provided path
+    windowMap.set(id, path)
+    set({ windowMap })
   },
 
   // maximise a window
@@ -181,7 +178,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
   setActiveWindowID: (id: number | null) => set({ activeWindowID: id }),
 
   // track active window's path
-  setActiveWindowPath: (path: string | null) => set({ activeWindowPath: path }),
+  setActiveWindowPath: (path: string) => set({ activeWindowPath: path }),
 }))
 
 export default useWindowStore

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -36,8 +36,6 @@ const useWindowStore = create<WindowState>((set, get) => ({
       return
     }
 
-    windowMap.delete(id)
-
     function isEven(num: number): boolean {
       return num % 2 === 0
     }
@@ -92,19 +90,6 @@ const useWindowStore = create<WindowState>((set, get) => ({
       return 1
     }
 
-    //  decrements id of window to parent id, if sibling is being deleted
-    // function validParent(map: Map<number, string | null>, id: number) {
-    //   //  saving path to set valid parent in map to that path
-    //   const path = map.get(id) ?? ''
-    //   const parentId = findValidParent(map, id)
-
-    //   if (parentId === 1) {
-    //     map.set(1, path)
-    //   } else {
-    //     map.set(parentId, path)
-    //   }
-    // }
-
     function handleDelete(map: Map<number, string | null>, id: number) {
       const siblingId = isEven(id) ? id + 1 : id - 1
       const siblingPath = map.get(siblingId) ?? null
@@ -145,6 +130,8 @@ const useWindowStore = create<WindowState>((set, get) => ({
       })
       set({ windowMap: newMap })
     }
+
+    windowMap.delete(id)
 
     if (id === 1) {
       set({ windowMap: defaultMap })

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import WindowState from './windowState'
 
-const defaultPath= `~sampel/home`
+const defaultPath = `~sampel/home`
 const defaultMap = new Map<number, string>([[1, defaultPath]])
 
 const useWindowStore = create<WindowState>((set, get) => ({
@@ -132,7 +132,11 @@ const useWindowStore = create<WindowState>((set, get) => ({
       }
       //  otherwise keep sibling window state
       //console.log('map', new Map(map))
-      set({ windowMap: map })
+      const newMap = new Map<number, string>()
+      map.forEach((value, key) => {
+        newMap.set(key, value ?? `${window.ship || window.urbitID}/home`)
+      })
+      set({ windowMap: newMap })
     }
 
     if (id === 1) {

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -136,7 +136,7 @@ const useWindowStore = create<WindowState>((set, get) => ({
       //console.log('map', new Map(map))
       const newMap = new Map<number, string>()
       map.forEach((value, key) => {
-        newMap.set(key, value ?? `${window.ship || window.urbitID}/home`)
+        newMap.set(key, value ?? defaultPath)
       })
       set({ windowMap: newMap })
     }

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -20,7 +20,9 @@ const useWindowStore = create<WindowState>((set, get) => ({
     // When splitting a window, the parent becomes a container window
     windowMap.set(parentId * 2, parentPath)
     windowMap.set(parentId * 2 + 1, path)
-    windowMap.set(parentId, defaultPath)
+    // TODO this is an awful concession to bad rendering logic
+    // inshallah we will fix it in another PR
+    windowMap.set(parentId, '')
 
     set({ windowMap })
   },

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -6,7 +6,6 @@ export default interface WindowState {
   activeWindowPath: string
   addWindow: (parentId: number, path: string) => void
   delWindow: (id: number) => void
-  clearWindows: () => void
   updateWindowPath: (id: number, path: string) => void
   setMaxWindow: (id: number) => void
   togglePathBarView: (id: number) => void

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -1,9 +1,9 @@
 export default interface WindowState {
-  windowMap: Map<number, string | null>
+  windowMap: Map<number, string>
   maxWindow: number
   pathBarView: Array<number>
   activeWindowID: number | null
-  activeWindowPath: string | null
+  activeWindowPath: string
   addWindow: (parentId: number, path: string) => void
   delWindow: (id: number) => void
   clearWindows: () => void
@@ -11,5 +11,5 @@ export default interface WindowState {
   setMaxWindow: (id: number) => void
   togglePathBarView: (id: number) => void
   setActiveWindowID: (id: number | null) => void
-  setActiveWindowPath: (path: string | null) => void
+  setActiveWindowPath: (path: string) => void
 }

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -2,13 +2,13 @@ export default interface WindowState {
   windowMap: Map<number, string>
   maxWindow: number
   pathBarView: Array<number>
-  activeWindowID: number | null
+  activeWindowID: number
   activeWindowPath: string
   addWindow: (parentId: number, path: string) => void
   delWindow: (id: number) => void
   updateWindowPath: (id: number, path: string) => void
   setMaxWindow: (id: number) => void
   togglePathBarView: (id: number) => void
-  setActiveWindowID: (id: number | null) => void
+  setActiveWindowID: (id: number) => void
   setActiveWindowPath: (path: string) => void
 }


### PR DESCRIPTION
Window state is now a map of ID to `string` rather than `string | null`, `activeWindowPath` can never be set to `null`.

If we move our cursor off a window and not onto another window, the `activeWindowPath` just stays at the last window we were active in. This feels like an improvement over the old UX as well as...
* Preventing a bug I've had where in one case, changes would be made to `~sampel/home` when I thought I was focussed on another window
* Removing one potential case in which the entire UI would be rendered in a window

This PR generally makes window state logic cleaner and more robust, mostly by making path and ID types non-nullable.