### PR TITLE
Home workspace

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
     setActiveWindowID,
   } = useWindowStore()
 
-  const {workspaceMap, activeWorkspace, setActiveWorkspace} = useWorkspaceStore()
+  const {workspaceMap, activeWorkspace, addWorkspace, setActiveWorkspace} = useWorkspaceStore()
 
   const [dragWindow, setDragWindow] = useState(0)
   const holdingKey = useRef(false)
@@ -141,6 +141,8 @@ function App() {
         console.log('Pressed CTRL+N')
         event.preventDefault()
 
+        //TODO: if in Home workspace create a new workspace
+        
         if (activeWindowID !== null && maxWindow === 0) {
           addWindow(activeWindowID, '')
         }
@@ -152,9 +154,8 @@ function App() {
         event.preventDefault()
 
         if(activeWorkspace === 'Home'){
-        // Should track last used workspace and set ActiveWorkspace to it 
-          setActiveWorkspace('Workspace1')
-
+          console.log('in Home space, creating new workspace')
+          addWorkspace([''])
         }else if(activeWindowID !== null && maxWindow === 0) {
           if (activeWindowID === 1) {
             updateWindowPath(activeWindowID, '')

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -244,7 +244,7 @@ function App() {
         </div>
       }
       {activeWorkspace === 'Home' && 
-          <div className="wf hf p3">
+          <div className="wf" style={{ height: `calc(100% - ${65}px)` }}>
             <Window
               id={maxWindow}
               path={'~sampel/home'}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import 'allotment/dist/style.css'
 import WindowContainer from './components/WindowContainer.tsx'
 import useWindowStore from './state/useWindowStore.ts'
+import useWorkspaceStore from './state/useWorkspaceStore.ts'
 import StatusBar from './components/StatusBar.tsx'
 import Window from './components/Window.tsx'
 import { useEffect, useState, useRef } from 'react'
@@ -16,6 +17,8 @@ function App() {
     updateWindowPath,
     setActiveWindowID,
   } = useWindowStore()
+
+  const {activeWorkspace, setActiveWorkspace} = useWorkspaceStore()
 
   const [dragWindow, setDragWindow] = useState(0)
   const holdingKey = useRef(false)
@@ -143,7 +146,11 @@ function App() {
         console.log('Pressed CTRL+W')
         event.preventDefault()
 
-        if (activeWindowID !== null && maxWindow === 0) {
+        if(activeWorkspace === 'Home'){
+        // Should track last used workspace and set ActiveWorkspace to it 
+          setActiveWorkspace('Workspace1')
+
+        }else if(activeWindowID !== null && maxWindow === 0) {
           if (activeWindowID === 1) {
             updateWindowPath(activeWindowID, '')
           } else {
@@ -193,6 +200,7 @@ function App() {
     addWindow,
     updateWindowPath,
     setActiveWindowID,
+    activeWorkspace
   ])
 
   // TODO handle real window.urbitID, not suitable for production
@@ -209,30 +217,43 @@ function App() {
         TODO this height calc is a kludge, fixes StatusBar
         shoving the WindowContainer off the bottom of the screen
       */}
-      <div className="wf relative" style={{ height: `calc(100% - ${65}px)` }}>
-        {maxWindow !== 0 && (
-          <div
-            className="wf hf absolute p3"
-            style={{ zIndex: 100, opacity: '98%' }}
-          >
+      {activeWorkspace === 'Workspace1'  &&
+        <div className="wf relative" style={{ height: `calc(100% - ${65}px)` }}>
+          {maxWindow !== 0 && (
+            <div
+              className="wf hf absolute p3"
+              style={{ zIndex: 100, opacity: '98%' }}
+            >
+              <Window
+                id={maxWindow}
+                path={windowMap.get(maxWindow) ?? ''}
+                handleDrop={handleDrop}
+                handleDragStart={handleDragStart}
+                dragWindow={dragWindow}
+              />
+            </div>
+          )}
+          <WindowContainer
+            map={windowMap}
+            id={1}
+            isVertical={window.innerWidth > window.innerHeight}
+            handleDrop={handleDrop}
+            handleDragStart={handleDragStart}
+            dragWindow={dragWindow}
+          />
+        </div>
+      }
+      {activeWorkspace === 'Home' && 
+          <div className="wf hf p3">
             <Window
               id={maxWindow}
-              path={windowMap.get(maxWindow) ?? ''}
+              path={'~sampel/home'}
               handleDrop={handleDrop}
               handleDragStart={handleDragStart}
               dragWindow={dragWindow}
             />
           </div>
-        )}
-        <WindowContainer
-          map={windowMap}
-          id={1}
-          isVertical={window.innerWidth > window.innerHeight}
-          handleDrop={handleDrop}
-          handleDragStart={handleDragStart}
-          dragWindow={dragWindow}
-        />
-      </div>
+      }
     </div>
   )
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState, useRef } from 'react'
 
 function App() {
   const {
-    windowMap,
+    //windowMap,
     maxWindow,
     activeWindowID,
     addWindow,
@@ -18,10 +18,14 @@ function App() {
     setActiveWindowID,
   } = useWindowStore()
 
-  const {activeWorkspace, setActiveWorkspace} = useWorkspaceStore()
+  const {workspaceMap, activeWorkspace, setActiveWorkspace} = useWorkspaceStore()
 
   const [dragWindow, setDragWindow] = useState(0)
   const holdingKey = useRef(false)
+
+  const defaultMap = new Map<number, string | null>([
+    [1, '~sampel/home']])
+  const windowMap = workspaceMap.get(activeWorkspace) ?? defaultMap
 
   function enableWindows() {
     setDragWindow(0)
@@ -140,6 +144,7 @@ function App() {
         if (activeWindowID !== null && maxWindow === 0) {
           addWindow(activeWindowID, '')
         }
+        console.log(workspaceMap)
       }
 
       if ((event.metaKey || event.ctrlKey) && event.key === 'w') {
@@ -200,7 +205,8 @@ function App() {
     addWindow,
     updateWindowPath,
     setActiveWindowID,
-    activeWorkspace
+    activeWorkspace,
+    workspaceMap
   ])
 
   // TODO handle real window.urbitID, not suitable for production
@@ -217,7 +223,6 @@ function App() {
         TODO this height calc is a kludge, fixes StatusBar
         shoving the WindowContainer off the bottom of the screen
       */}
-      {activeWorkspace === 'Workspace1'  &&
         <div className="wf relative" style={{ height: `calc(100% - ${65}px)` }}>
           {maxWindow !== 0 && (
             <div
@@ -242,8 +247,7 @@ function App() {
             dragWindow={dragWindow}
           />
         </div>
-      }
-      {activeWorkspace === 'Home' && 
+      {/* {activeWorkspace === 'Home' && 
           <div className="wf" style={{ height: `calc(100% - ${65}px)` }}>
             <Window
               id={maxWindow}
@@ -253,7 +257,7 @@ function App() {
               dragWindow={dragWindow}
             />
           </div>
-      }
+      } */}
     </div>
   )
 }

--- a/ui/src/components/StatusBar.tsx
+++ b/ui/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import '@urbit/sigil-js'
 import bellIcon from '../assets/images/bell.png'
 import closeIcon from '../assets/images/close.png'
+import useWorkspaceStore from '../state/useWorkspaceStore'
 
 const sigilConfig = {
   // TODO don't hard-code height all over this component
@@ -16,6 +17,8 @@ const sigilConfig = {
 }
 
 export default function StatusBar() {
+  const { setActiveWorkspace } = useWorkspaceStore()
+
   return (
     <div className="fr ac jb" style={{ height: '50px' }}>
       <div
@@ -27,7 +30,8 @@ export default function StatusBar() {
           width: '200px',
         }}
       >
-        <span>Workspace 1</span>
+        <span onClick={()=>{setActiveWorkspace('home')}}>Home</span>
+        <span onClick={()=>{setActiveWorkspace('Workspace1')}}>Workspace 1</span>
         <div>
           <img
             style={{ height: '10px', width: '10px' }}

--- a/ui/src/components/StatusBar.tsx
+++ b/ui/src/components/StatusBar.tsx
@@ -17,21 +17,32 @@ const sigilConfig = {
 }
 
 export default function StatusBar() {
-  const { setActiveWorkspace } = useWorkspaceStore()
+  const { workspaces, activeWorkspace, setActiveWorkspace } = useWorkspaceStore()
 
+  function toggleActiveWorkspace(workspace: string) {
+
+    setActiveWorkspace(workspace)
+
+
+  }
   return (
-    <div className="fr ac jb" style={{ height: '50px' }}>
+    <div className="fr ac jb" style={{ padding: '5px', height: '50px' }}>
+      <div className="fr ac g1">
+      {workspaces.map((workspace) => (
       <div
-        className="br1 fr ac jb b1"
+        key={workspace} 
+        className={activeWorkspace === workspace ? "br1 fr ac jb b2" : "br1 fr ac jb b1"}
         style={{
           height: '30px',
           paddingLeft: '10px',
           paddingRight: '10px',
           width: '200px',
         }}
+        onClick={() => toggleActiveWorkspace(workspace)}
       >
-        <span onClick={()=>{setActiveWorkspace('home')}}>Home</span>
-        <span onClick={()=>{setActiveWorkspace('Workspace1')}}>Workspace 1</span>
+        <span>
+          {workspace}
+        </span>
         <div>
           <img
             style={{ height: '10px', width: '10px' }}
@@ -39,6 +50,8 @@ export default function StatusBar() {
             alt="Close space"
           />
         </div>
+      </div>
+      ))}
       </div>
       <div className="fr ac jb" style={{ height: '30px' }}>
         <div

--- a/ui/src/components/StatusBar.tsx
+++ b/ui/src/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import '@urbit/sigil-js'
 import bellIcon from '../assets/images/bell.png'
 import closeIcon from '../assets/images/close.png'
 import useWorkspaceStore from '../state/useWorkspaceStore'
+import useWindowStore from '../state/useWindowStore'
 
 const sigilConfig = {
   // TODO don't hard-code height all over this component
@@ -17,18 +18,23 @@ const sigilConfig = {
 }
 
 export default function StatusBar() {
-  const { workspaces, activeWorkspace, setActiveWorkspace } = useWorkspaceStore()
+  const { workspaceMap, activeWorkspace, setActiveWorkspace } = useWorkspaceStore()
+  const {setWindowMap} = useWindowStore()
 
   function toggleActiveWorkspace(workspace: string) {
-
+  console.log('running setActiveWorkspace(workspace)', workspace)
     setActiveWorkspace(workspace)
-
-
+    const windowMap = workspaceMap.get(workspace);
+    console.log('all maps', workspaceMap)
+    if(windowMap !== undefined){
+      console.log('get workspace', windowMap)
+      setWindowMap(windowMap)
+    }
   }
   return (
     <div className="fr ac jb" style={{ padding: '5px', height: '50px' }}>
       <div className="fr ac g1">
-      {workspaces.map((workspace) => (
+      {Array.from(workspaceMap).map(([workspace, windowMap]) => (
       <div
         key={workspace} 
         className={activeWorkspace === workspace ? "br1 fr ac jb b2" : "br1 fr ac jb b1"}

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -9,6 +9,7 @@ import useWindowStore from '../state/useWindowStore'
 import TextHTML from './renderers/TextHTML'
 import ApplicationPDF from './renderers/ApplicationPDF'
 import TextPlain from './renderers/TextPlain'
+import useWorkspaceStore from '../state/useWorkspaceStore'
 
 export interface WindowProps {
   id: number
@@ -54,6 +55,8 @@ export default function Window({
     setActiveWindowPath,
     delWindow,
   } = useWindowStore()
+
+  const {activeWorkspace, addWorkspace} = useWorkspaceStore()
 
   function handleWindowMouseEnter() {
     setActiveWindowID(id)
@@ -233,6 +236,10 @@ export default function Window({
 
   async function renderContent(path: string) {
     console.log('render', path)
+    if(path !== '~sampel/home' && activeWorkspace === 'Home'){
+      addWorkspace([path])
+    }
+
     try {
       const res = await get(path)
       console.log('Data in renderContent is', res)

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -11,6 +11,11 @@ const useWindowStore = create<WindowState>((set, get) => ({
   activeWindowID: 1,
   activeWindowPath: defaultPath,
 
+  setWindowMap: (windowMap: Map<number, string | null>) => {
+    console.log('setting window map to , windowMap')
+    set({ windowMap })
+  },
+
   // add a new window to the tree
   addWindow: (parentId: number, path: string) => {
     const windowMap = get().windowMap

--- a/ui/src/state/useWorkspaceStore.ts
+++ b/ui/src/state/useWorkspaceStore.ts
@@ -14,6 +14,7 @@ const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     console.log('setting workspace to ', workspace )
     if(workspaces.includes(workspace)){
       set({ activeWorkspace: workspace })
+      console.log('updated activeWorksapce in useWorkspaceStore ', get().activeWorkspace)
     }
   }
 }))

--- a/ui/src/state/useWorkspaceStore.ts
+++ b/ui/src/state/useWorkspaceStore.ts
@@ -4,8 +4,8 @@ import WorkspaceState from './workspaceState'
 const defaultPath = '~sampel/home'
 const defaultWindowMap = new Map<number, string | null>([[1, defaultPath]])
 const defaultMap = new Map<string, Map<number, string | null>>([
-    ['Home', defaultWindowMap],
-    ['Workspace1', defaultWindowMap]
+    ['Home', defaultWindowMap]
+    // ['Workspace1', defaultWindowMap]
 ])
 
 const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
@@ -17,7 +17,11 @@ const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     const workspaceMap = get().workspaceMap
     const index = workspaceMap.size
     const newWorkspace = `Workspace${index}`
+    //  TODO: store paths in WindowMap as a tree like structure rather than just index to path
     const windowMap = new Map<number, string | null>(paths.map((path, i) => [i, path]))
+
+    console.log('setting up new ', newWorkspace)
+
     workspaceMap.set(newWorkspace, windowMap)
     set({ 
         workspaceMap: workspaceMap,

--- a/ui/src/state/useWorkspaceStore.ts
+++ b/ui/src/state/useWorkspaceStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+import WorkspaceState from './workspaceState'
+
+const defaultWorkspaces = ['Home', 'Workspace1']
+
+const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+
+  // init default state values
+  workspaces: defaultWorkspaces,
+  activeWorkspace: 'Home',
+
+  setActiveWorkspace: (workspace: string) => {
+    const workspaces = get().workspaces
+    console.log('setting workspace to ', workspace )
+    if(workspaces.includes(workspace)){
+      set({ activeWorkspace: workspace })
+    }
+  }
+}))
+
+export default useWorkspaceStore

--- a/ui/src/state/useWorkspaceStore.ts
+++ b/ui/src/state/useWorkspaceStore.ts
@@ -1,18 +1,40 @@
 import { create } from 'zustand'
 import WorkspaceState from './workspaceState'
 
-const defaultWorkspaces = ['Home', 'Workspace1']
+const defaultPath = '~sampel/home'
+const defaultWindowMap = new Map<number, string | null>([[1, defaultPath]])
+const defaultMap = new Map<string, Map<number, string | null>>([
+    ['Home', defaultWindowMap],
+    ['Workspace1', defaultWindowMap]
+])
 
 const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
-
   // init default state values
-  workspaces: defaultWorkspaces,
+  workspaceMap: defaultMap,
   activeWorkspace: 'Home',
 
+  addWorkspace: (paths: Array<string>) =>{
+    const workspaceMap = get().workspaceMap
+    const index = workspaceMap.size
+    const newWorkspace = `Workspace${index}`
+    const windowMap = new Map<number, string | null>(paths.map((path, i) => [i, path]))
+    workspaceMap.set(newWorkspace, windowMap)
+    set({ 
+        workspaceMap: workspaceMap,
+        activeWorkspace: newWorkspace
+    })
+  },
+
+  removeWorkspace(workspace: string) {
+    const workspaceMap = get().workspaceMap
+    workspaceMap.delete(workspace)
+    set({ workspaceMap: workspaceMap})
+  },
+
   setActiveWorkspace: (workspace: string) => {
-    const workspaces = get().workspaces
-    console.log('setting workspace to ', workspace )
-    if(workspaces.includes(workspace)){
+    const workspaceMap = get().workspaceMap
+    console.log('is ', workspaceMap.has(workspace))
+    if(workspaceMap.has(workspace)){
       set({ activeWorkspace: workspace })
       console.log('updated activeWorksapce in useWorkspaceStore ', get().activeWorkspace)
     }

--- a/ui/src/state/windowState.ts
+++ b/ui/src/state/windowState.ts
@@ -3,6 +3,7 @@ export default interface WindowState {
   maxWindow: number
   activeWindowID: number | null
   activeWindowPath: string | null
+  setWindowMap: (windowMap: Map<number, string | null>) => void
   addWindow: (parentId: number, path: string) => void
   delWindow: (id: number) => void
   clearWindows: () => void

--- a/ui/src/state/workspaceState.ts
+++ b/ui/src/state/workspaceState.ts
@@ -1,6 +1,8 @@
 export default interface WorkspaceState {
     //  for now tbd
-    workspaces: Array<string>
+    workspaceMap: Map<string, Map<number, string | null>>
     activeWorkspace: string
+    addWorkspace: (paths: Array<string>) => void
+    removeWorkspace: (workspace: string) => void
     setActiveWorkspace: (workspace: string) => void
   }

--- a/ui/src/state/workspaceState.ts
+++ b/ui/src/state/workspaceState.ts
@@ -1,0 +1,6 @@
+export default interface WorkspaceState {
+    //  for now tbd
+    workspaces: Array<string>
+    activeWorkspace: string
+    setActiveWorkspace: (workspace: string) => void
+  }


### PR DESCRIPTION
Closes #76 
*  Home workspace button displays page at `~sampel/home` path 
* On `CTRL+w` returns back to `Workspace1`.

_TODO:_
- [ ] Implement WorkspaceMap to store WindowMap for each workspace.
- [ ] On `CTRL+n` keyboard shortcut creates a new workspace, with 2 windows `~sampel/home` and empty path window 
- [ ] On change path in `Home` workspace creates a new workspace with a window to a new path