### PR TITLE
Fix FileSystem navbar

### DIFF
--- a/ui/src/components/renderers/FileSystem.tsx
+++ b/ui/src/components/renderers/FileSystem.tsx
@@ -192,7 +192,9 @@ export default function FileSystem({ id, path }: FileSystemProps): JSX.Element {
   }, [path])
 
   function handlePathSegmentClick(index: number) {
-    updateWindowPath(id, path.split('/').slice(index).join('/'))
+    const segments = path.split('/')
+    const newPath = segments.slice(0, index + 1).join('/')
+    updateWindowPath(id, newPath)
   }
 
   function handleAddSegment() {


### PR DESCRIPTION
Fixes navbar logic so that clicking path segments will take you to the correct path.

Note that clicking a path segment leading to some content will render that content in the "normal" renderer, not the appropriate file renderer. This is bad UX should be fixed once this is change is merged alongside #87, which tracks whether a given window should render its content in the file viewer or the normal renderer.