### PR TITLE
Remove hard-coded ~zod from frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Urbit namespace browser, spiritual successor to the [urbit/shrub](https://github
 
 ## Developer Environment Setup
 
-The developer environment requires a fakeship and expects that fakeship to be running on localhost:80, but you can configure that URL in an .env.local file in the `/ui` folder.
+The developer environment requires a fakeship and expects that fakeship to be running on localhost:80, but you can specify another port in an .env.local file in the `/ui` folder.
 
 ```
-VITE_SHIP_URL=http://localhost:80
+VITE_SHIP_URL=http://localhost:8080
 ```
 
 Boot up your fakeship and copy the contents of `/desk` to its %sky desk.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Urbit namespace browser, spiritual successor to the [urbit/shrub](https://github
 
 ## Developer Environment Setup
 
-The developer environment requires a fake \~zod (yes, it has to be \~zod) and expects that \~zod to be running on localhost:8080, but you can configure that URL in an .env.local file in the `/ui` folder.
+The developer environment requires a fakeship and expects that fakeship to be running on localhost:80, but you can configure that URL in an .env.local file in the `/ui` folder.
 
 ```
 VITE_SHIP_URL=http://localhost:80
 ```
 
-Boot up your fake \~zod and copy the contents of `/desk` to its %sky desk.
+Boot up your fakeship and copy the contents of `/desk` to its %sky desk.
 
 ```
 $ ./urbit -F zod
@@ -40,5 +40,5 @@ $ pnpm install
 $ pnpm dev
 ```
 
-Go to the Vite URL in the terminal ending `/apps/sky` to use Sky.
+Go to `http://127.0.0.1:5173/apps/sky/` to use Sky.
 

--- a/desk/app/seer.hoon
+++ b/desk/app/seer.hoon
@@ -185,7 +185,11 @@
         ?~  pax
           ~&  >>>  "No data received"
           [(send [400 ~ [%plain "No data received"]]) state]
-        =/  =path  (cut-path value.u.pax '/')
+        =/  =path
+          ::  handle relative paths from root
+          ?.  =('/' (head (trip value.u.pax)))
+            (cut-path value.u.pax '/')
+          (welp /[(scot %p our.bowl)] (cut-path value.u.pax '/'))
         ::  ~&  >>  sky.bowl
         =/  =ship  `@p`(slav %p (head path))
         ?:  =(ship our.bowl)

--- a/desk/fil/home.html
+++ b/desk/fil/home.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home Screen</title>
-    <link rel="stylesheet" href="/seer?path=~zod/sys/css/hollow">
-    <link rel="stylesheet" href="/seer?path=~zod/sys/css/spine">
-    <link rel="stylesheet" href="/seer?path=~zod/sys/css/feather">
+    <link rel="stylesheet" href="/seer?path=/sys/css/hollow">
+    <link rel="stylesheet" href="/seer?path=/sys/css/spine">
+    <link rel="stylesheet" href="/seer?path=/sys/css/feather">
 </head>
 <body class="p4 b1">
     <div class="hf wf fr ac jc b1">
@@ -22,7 +22,7 @@
         </div>
     </div>
     <script type="module">
-    import { get } from '/seer?path=~zod/sys/js/api'
+    import { get } from '/seer?path=/sys/js/api'
 
     async function makeTiles() {
         const res = await get('~zod/app-data')

--- a/desk/fil/home.html
+++ b/desk/fil/home.html
@@ -25,7 +25,7 @@
     import { get } from '/seer?path=/sys/js/api'
 
     async function makeTiles() {
-        const res = await get('~zod/app-data')
+        const res = await get('/app-data')
         const data = await res.json()
 
         const appContainer = document.getElementById('app-container')

--- a/desk/fil/home.html
+++ b/desk/fil/home.html
@@ -12,9 +12,9 @@
     <div class="hf wf fr ac jc b1">
         <div class="hf fc ac js">
             <!-- path bar -->
-            <div class="wf fr ac jc">
-                <input type="text" placeholder="~zod/home" />
-            </div>
+            <!--<div class="wf fr ac jc">-->
+            <!--    <input type="text" placeholder="~zod/home" />-->
+            <!--</div>-->
             <!-- tiles -->
             <div id="app-container" class="wf fr as js frw" style="width: 500px; flex-wrap: wrap; margin-top: 8px;">
                 <!-- App tiles will be generated here -->

--- a/desk/fil/sys/js/api.js
+++ b/desk/fil/sys/js/api.js
@@ -1,11 +1,24 @@
 // TODO handle relative get('foo')
-// TODO handle relative get('/foo')
-// TODO handle relative get('~/foo')
-// TODO remove hard-coded URLs
 async function get(path) {
+  if (path.startsWith('/')) {
+    try {
+      const res = await fetch(`${window.location.origin}/seer?path=${path}`, {
+        method: 'GET',
+        credentials: 'include',
+      })
+
+      if (!res.ok) {
+        throw new Error(`Response not ok from ${window.location.origin}/seer?path=${path}`)
+      }
+
+      return res
+    } catch(err) {
+      console.error(`GET request to ${path} failed at ${window.location.origin}/seer?path=${path}`, err)
+    }
+  }
+
   const pathArray = path.split('/')
   const pathShip = pathArray[0]
-  const endpoint = pathArray.slice(1).join('/')
 
   try {
     const res = await fetch(`${window.location.origin}/seer?path=${path}`, {
@@ -25,8 +38,6 @@ async function get(path) {
 
 // TODO handle relative put('foo', file)
 // TODO handle relative put('/foo', file)
-// TODO handle relative put('~/foo', file)
-// TODO remove hard-coded URLs
 async function put(path, file) {
   const url = `${window.location.origin}/seer?path=${path}&mime=${file.type}&name=${file.name}`
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,17 +7,17 @@
     <meta name="description" content="Sky" />
     <link
       rel="stylesheet"
-      href="%VITE_SHIP_URL%/seer?path=~zod/sys/css/hollow"
+      href="%VITE_SHIP_URL%/seer?path=/sys/css/hollow"
     />
     <link
       rel="stylesheet"
-      href="%VITE_SHIP_URL%/seer?path=~zod/sys/css/spine"
+      href="%VITE_SHIP_URL%/seer?path=/sys/css/spine"
     />
     <link
       rel="stylesheet"
-      href="%VITE_SHIP_URL%/seer?path=~zod/sys/css/feather"
+      href="%VITE_SHIP_URL%/seer?path=/sys/css/feather"
     />
-    <link rel="stylesheet" href="%VITE_SHIP_URL%/seer?path=~zod/sys/css/wind" />
+    <link rel="stylesheet" href="%VITE_SHIP_URL%/seer?path=/sys/css/wind" />
     <title>Sky</title>
     <link rel="manifest" href="./manfiest.json" />
     <meta name="theme-color" content="#ffffff" />

--- a/ui/src/api/sky.ts
+++ b/ui/src/api/sky.ts
@@ -5,10 +5,25 @@ const ourDomain = (): string => {
 }
 
 // TODO handle relative get('foo')
-// TODO handle relative get('/foo')
-// TODO handle relative get('~/foo')
 // TODO remove hard-coded URLs
 async function get(path: string): Promise<Response | void> {
+  if (path.startsWith('/')) {
+    try {
+      const res = await fetch(`${ourDomain()}/seer?path=${path}`, {
+        method: 'GET',
+        credentials: 'include',
+      })
+
+      if (!res.ok) {
+        throw new Error(`Response not ok from ${ourDomain()}/seer?path=${path}`)
+      }
+
+      return res
+    } catch(err) {
+      console.error(`GET request to ${path} failed at ${ourDomain()}/seer?path=${path}`, err)
+    }
+  }
+
   const pathArray = path.split('/')
   const pathShip = pathArray[0]
   const endpoint = pathArray.slice(1).join('/')

--- a/ui/src/api/sky.ts
+++ b/ui/src/api/sky.ts
@@ -1,6 +1,6 @@
 const ourDomain = (): string => {
   return import.meta.env.MODE !== 'production'
-    ? import.meta.env.VITE_SHIP_URL || 'http://localhost:8080'
+    ? import.meta.env.VITE_SHIP_URL || 'http://localhost:80'
     : window.location.origin
 }
 

--- a/ui/src/components/StatusBar.tsx
+++ b/ui/src/components/StatusBar.tsx
@@ -57,7 +57,7 @@ export default function StatusBar() {
   const isEmptyWorkspace = (workspace: Workspace) => {
     const paths = Array.from(workspace.windowState.windowMap.values())
     return (
-      workspace.name === '' && paths.length === 1 && paths[0] === '~zod/home'
+      workspace.name === '' && paths.length === 1 && paths[0] === `~${window.ship}/home`
     )
   }
 
@@ -70,7 +70,7 @@ export default function StatusBar() {
     // TODO don't hard-code height all over this component
     // changing size in sigilConfig upsets layout
     size: '30px',
-    point: `~${window.ship || 'zod'}`,
+    point: `~${window.ship}`,
     // TODO get colors from tlon/landscape user preferences
     foreground: '#FFF',
     background: '#c10c31',

--- a/ui/src/components/renderers/FileComposer.tsx
+++ b/ui/src/components/renderers/FileComposer.tsx
@@ -271,7 +271,7 @@ export default function FileComposer({ path }: FileComposerProps): JSX.Element {
             <div className="hf wf p2">
               <iframe
                 className="hf wf"
-                src={`${ourDomain()}/seer?path=~zod/sys/tmp/${endpoint}`}
+                src={`${ourDomain()}/seer?path=/sys/tmp/${endpoint}`}
                 style={{ border: 'none', borderRadius: '2.5px' }}
                 sandbox="allow-scripts allow-same-origin"
               ></iframe>

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -108,7 +108,7 @@ function sendWorkspacesStateToNamespace(store: WorkspaceStore): void {
       { type: 'application/json' }
     )
 
-    put('~zod/sys/state/workspaces', stateFile)
+    put(`~${window.ship}/sys/state/workspaces`, stateFile)
   } catch (err) {
     console.error('Failed to save workspaces state to namespace: ', err)
   }

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -117,7 +117,7 @@ function sendWorkspacesStateToNamespace(store: WorkspaceStore): void {
 }
 
 // default state values
-const defaultPath: Path = '~zod/home'
+const defaultPath: Path = `~${window.ship}/home`
 const defaultMap: WindowMap = new Map<WindowID, Path>([[1, defaultPath]])
 
 const defaultWindowState: WindowStateObject = {

--- a/ui/src/state/useWindowStore.ts
+++ b/ui/src/state/useWindowStore.ts
@@ -108,8 +108,6 @@ function sendWorkspacesStateToNamespace(store: WorkspaceStore): void {
       { type: 'application/json' }
     )
 
-    // TODO remove hard-coded @p; API should accept relative paths
-    // can't use window.ship in this file
     put('~zod/sys/state/workspaces', stateFile)
   } catch (err) {
     console.error('Failed to save workspaces state to namespace: ', err)

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -6,7 +6,7 @@ import { urbitPlugin } from '@urbit/vite-plugin-urbit'
 export default ({ mode }) => {
   Object.assign(process.env, loadEnv(mode, process.cwd()))
   const SHIP_URL =
-    process.env.SHIP_URL || process.env.VITE_SHIP_URL || 'http://localhost:8080'
+    process.env.SHIP_URL || process.env.VITE_SHIP_URL || 'http://localhost:80'
   console.log(`Connecting to ${SHIP_URL}`)
 
   return defineConfig({


### PR DESCRIPTION
Sky now works on ships other than a fake ~zod. This involves handling requests to relative paths like `/sys/css/spine` rather than `~zod/sys/css/spine` in both the Namespace API and in the %seer agent.

Also now uses :80 rather than :8080 as the default port we expect the fakeship to be running on, since that proved to be a UX papercut.