### PR TITLE
Improve MIME type handling

### DIFF
--- a/desk/app/seer.hoon
+++ b/desk/app/seer.hoon
@@ -150,18 +150,15 @@
         ?~  body
           [(send [400 ~ [%plain "No data received"]]) state]
         ::  ~&  >>  body
-        =/  nym  (cut-path value.u.name '.')
-        ::  ~&  >  nym
-        =/  ext  (rear nym)
-        ::  ~&  >  ext
-        =/  mim  ((type-to-mime ext) ((noun-to-type ext) q.u.body))
+        ::  ~&  >>  u.body
+        =/  mym  [(cut-path value.u.mime '/') u.body]
         :_  state
         ::  XX is there a gift at /call/back/path?
         %+  welp
           (send [200 ~ [%plain "Success"]])
         :~  :*  %pass  ~
                 %grow  (tail (cut-path value.u.pax '/'))
-                [%mime mim]
+                [%mime mym]
             ==
         ==
       ::

--- a/desk/app/seer.hoon
+++ b/desk/app/seer.hoon
@@ -194,7 +194,7 @@
           ::  our path
           =/  ver  (~(get by sky.bowl) (tail path))
           ?~  ver
-            ~&  >>>  "No versions of {<path>}"
+            ::  ~&  >>>  "No versions of {<path>}"
             [(send [404 ~ [%plain "Not found"]]) state]
           =/  on-path  ((on @ud (pair @da (each page @uvI))) lte)
           ::  XX i think +ram is getting latest date

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -109,74 +109,75 @@ export default function Window({
         return notRecognizedContent()
       }
 
-      switch (contentType.split(';')[0]) {
-        case 'text/plain': {
-          const txt = await res.text()
-          return <TextPlain text={txt} />
-        }
-        case 'text/html': {
-          if (res.url) {
-            return <TextHTML url={res.url} />
-          }
+      const mimeType = contentType.split(';')[0]
+      const mainType = mimeType.split('/')[0]
+      const subType = mimeType.split('/')[1]
 
-          return <div>{`No URLs found for ${path}`}</div>
+      // Group by main MIME type
+      switch (mainType) {
+        case 'text': {
+          switch (subType) {
+            case 'html': {
+              if (res.url) {
+                return <TextHTML url={res.url} />
+              }
+              return <div>{`No URLs found for ${path}`}</div>
+            }
+            case 'markdown':
+            case 'x-markdown': {
+              const text = await res.text()
+              return <TextMarkdown md={text} />
+            }
+            // Default text handler for plain, css, javascript, etc.
+            default: {
+              const txt = await res.text()
+              return <TextPlain text={txt} />
+            }
+          }
         }
-        case 'text/markdown': {
-          const text = await res.text()
-          return <TextMarkdown md={text} />
+
+        case 'application': {
+          switch (subType) {
+            case 'pdf': {
+              const blob = await res.blob()
+              const pdfURL = URL.createObjectURL(blob)
+              return <ApplicationPDF pdf={pdfURL} />
+            }
+            // Handle json, xml and other application types as text
+            case 'json':
+            case 'xml': {
+              const txt = await res.text()
+              return <TextPlain text={txt} />
+            }
+            default: {
+              return notRecognizedContent(mimeType)
+            }
+          }
         }
-        case 'text/x-markdown': {
-          const text = await res.text()
-          return <TextMarkdown md={text} />
-        }
-        case 'text/css': {
-          const txt = await res.text()
-          return <TextPlain text={txt} />
-        }
-        case 'text/javascript': {
-          const txt = await res.text()
-          return <TextPlain text={txt} />
-        }
-        case 'application/json': {
-          const txt = await res.text()
-          return <TextPlain text={txt} />
-        }
-        case 'application/xml': {
-          const txt = await res.text()
-          return <TextPlain text={txt} />
-        }
-        case 'application/pdf': {
-          const blob = await res.blob()
-          const pdfURL = URL.createObjectURL(blob)
-          return <ApplicationPDF pdf={pdfURL} />
-        }
-        case 'image/jpeg': {
+
+        case 'image': {
+          // All image types can use the Image component
           const blob = await res.blob()
           const objectURL = URL.createObjectURL(blob)
           return <Image url={objectURL} />
         }
-        case 'image/png': {
-          const blob = await res.blob()
-          const objectURL = URL.createObjectURL(blob)
-          return <Image url={objectURL} />
-        }
-        case 'video/mp4': {
+
+        case 'video': {
+          // All video types can use the Video component
           const blob = await res.blob()
           const objectURL = URL.createObjectURL(blob)
           return <Video url={objectURL} />
         }
-        case 'video/quicktime': {
-          const blob = await res.blob()
-          const objectURL = URL.createObjectURL(blob)
-          return <Video url={objectURL} />
-        }
-        case 'audio/mpeg': {
+
+        case 'audio': {
+          // All audio types can use the Audio component
           const blob = await res.blob()
           const objectURL = URL.createObjectURL(blob)
           return <Audio url={objectURL} />
         }
+
         default: {
-          return notRecognizedContent(contentType.split(';')[0])
+          return notRecognizedContent(mimeType)
         }
       }
     }

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -9,6 +9,7 @@ import useWindowStore from '../state/useWindowStore'
 import TextHTML from './renderers/TextHTML'
 import ApplicationPDF from './renderers/ApplicationPDF'
 import TextPlain from './renderers/TextPlain'
+import Video from './renderers/Video'
 
 export interface WindowProps {
   id: number
@@ -159,11 +160,14 @@ export default function Window({
           return <Image url={objectURL} />
         }
         case 'video/mp4': {
-          return (
-            <>
-              <p>MP4 video content is not currently displayed.</p>
-            </>
-          )
+          const blob = await res.blob()
+          const objectURL = URL.createObjectURL(blob)
+          return <Video url={objectURL} />
+        }
+        case 'video/quicktime': {
+          const blob = await res.blob()
+          const objectURL = URL.createObjectURL(blob)
+          return <Video url={objectURL} />
         }
         case 'audio/mpeg': {
           return (

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -123,6 +123,10 @@ export default function Window({
           const text = await res.text()
           return <TextMarkdown md={text} />
         }
+        case 'text/x-markdown': {
+          const text = await res.text()
+          return <TextMarkdown md={text} />
+        }
         case 'text/css': {
           const txt = await res.text()
           return <TextPlain text={txt} />

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -10,6 +10,7 @@ import TextHTML from './renderers/TextHTML'
 import ApplicationPDF from './renderers/ApplicationPDF'
 import TextPlain from './renderers/TextPlain'
 import Video from './renderers/Video'
+import Audio from './renderers/Audio'
 
 export interface WindowProps {
   id: number
@@ -170,11 +171,9 @@ export default function Window({
           return <Video url={objectURL} />
         }
         case 'audio/mpeg': {
-          return (
-            <>
-              <p>MP3 audio content is not currently displayed.</p>
-            </>
-          )
+          const blob = await res.blob()
+          const objectURL = URL.createObjectURL(blob)
+          return <Audio url={objectURL} />
         }
         default: {
           return notRecognizedContent

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -64,9 +64,9 @@ export default function Window({
     setActiveWindowPath(path)
   }
 
-  const notRecognizedContent = (
+  const notRecognizedContent = (mimeType?: string) => (
     <div className="hf wf p2 fc ac jc">
-      <p>Unrecognized MIME type</p>
+      <p>Unrecognized MIME type{mimeType ? `: ${mimeType}` : ''}</p>
     </div>
   )
 
@@ -106,7 +106,7 @@ export default function Window({
       const contentType = res.headers.get('Content-Type')
 
       if (!contentType) {
-        return notRecognizedContent
+        return notRecognizedContent()
       }
 
       switch (contentType.split(';')[0]) {
@@ -176,7 +176,7 @@ export default function Window({
           return <Audio url={objectURL} />
         }
         default: {
-          return notRecognizedContent
+          return notRecognizedContent(contentType.split(';')[0])
         }
       }
     }

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -1,6 +1,6 @@
 import { Allotment } from 'allotment'
 import { get } from '../api/sky'
-import ImagePNG from './renderers/ImagePNG'
+import Image from './renderers/Image'
 import TextMarkdown from './renderers/TextMarkdown'
 import PathBar from './PathBar'
 import FileSystem from './renderers/FileSystem'
@@ -149,16 +149,14 @@ export default function Window({
           return <ApplicationPDF pdf={pdfURL} />
         }
         case 'image/jpeg': {
-          return (
-            <>
-              <p>JPEG image content is not currently displayed.</p>
-            </>
-          )
+          const blob = await res.blob()
+          const objectURL = URL.createObjectURL(blob)
+          return <Image url={objectURL} />
         }
         case 'image/png': {
           const blob = await res.blob()
           const objectURL = URL.createObjectURL(blob)
-          return <ImagePNG url={objectURL} />
+          return <Image url={objectURL} />
         }
         case 'image/gif': {
           return (
@@ -383,17 +381,17 @@ export default function Window({
                   {!(
                     path === '' || path?.split('/')[0].slice(1) !== window.ship
                   ) && (
-                    <button
-                      className="fr ac jc"
-                      style={{ pointerEvents: 'visible' }}
-                      onMouseEnter={() => {
-                        setOpenOptionsMenu(true)
-                        setOpenVisibilityMenu(false)
-                      }}
-                    >
-                      ...
-                    </button>
-                  )}
+                      <button
+                        className="fr ac jc"
+                        style={{ pointerEvents: 'visible' }}
+                        onMouseEnter={() => {
+                          setOpenOptionsMenu(true)
+                          setOpenVisibilityMenu(false)
+                        }}
+                      >
+                        ...
+                      </button>
+                    )}
                   <button
                     className="fr ac jc"
                     style={{ pointerEvents: 'visible' }}

--- a/ui/src/components/Window.tsx
+++ b/ui/src/components/Window.tsx
@@ -158,13 +158,6 @@ export default function Window({
           const objectURL = URL.createObjectURL(blob)
           return <Image url={objectURL} />
         }
-        case 'image/gif': {
-          return (
-            <>
-              <p>GIF image content is not currently displayed.</p>
-            </>
-          )
-        }
         case 'video/mp4': {
           return (
             <>

--- a/ui/src/components/renderers/Audio.tsx
+++ b/ui/src/components/renderers/Audio.tsx
@@ -1,0 +1,11 @@
+interface AudioProps {
+  url: string
+}
+
+export default function Audio({ url }: AudioProps): JSX.Element {
+  return (
+    <div className="hf wf fc ac jc">
+      <audio src={url} controls className="wf" />
+    </div>
+  )
+}

--- a/ui/src/components/renderers/FileAudio.tsx
+++ b/ui/src/components/renderers/FileAudio.tsx
@@ -1,0 +1,11 @@
+interface FileAudioProps {
+  url: string
+}
+
+export default function FileAudio({ url }: FileAudioProps): JSX.Element {
+  return (
+    <div className="hf wf fc ac jc p2">
+      <audio src={url} controls className="wf" />
+    </div>
+  )
+}

--- a/ui/src/components/renderers/FileImage.tsx
+++ b/ui/src/components/renderers/FileImage.tsx
@@ -1,8 +1,8 @@
-interface FilePNGProps {
+interface FileImageProps {
   url: string
 }
 
-export default function FilePNG({ url }: FilePNGProps): JSX.Element {
+export default function FileImage({ url }: FileImageProps): JSX.Element {
   return (
     <div className="hf wf fc ac jc p2">
       <img src={url} alt="PNG image" style={{ objectFit: 'contain' }} />

--- a/ui/src/components/renderers/FileSystem.tsx
+++ b/ui/src/components/renderers/FileSystem.tsx
@@ -19,6 +19,7 @@ const composerContentTypes = new Set([
   'application/json',
   'application/xml',
   'text/markdown',
+  'text/x-markdown',
 ])
 
 async function renderFile(path: string, res: Response): Promise<JSX.Element> {

--- a/ui/src/components/renderers/FileSystem.tsx
+++ b/ui/src/components/renderers/FileSystem.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import useWindowStore from '../../state/useWindowStore'
 import { get, put } from '../../api/sky'
-import FilePNG from './FilePNG'
+import FileImage from './FileImage'
 import FileComposer from './FileComposer'
 import FilePDF from './FilePDF'
 
@@ -30,30 +30,39 @@ async function renderFile(path: string, res: Response): Promise<JSX.Element> {
     return <p>No content type found</p>
   }
 
-  const baseContentType = contentType.split(';')[0]
+  const mimeType = contentType.split(';')[0]
 
-  if (composerContentTypes.has(baseContentType)) {
+  // Check if it's a text or other composer-friendly type
+  if (composerContentTypes.has(mimeType)) {
     return <FileComposer path={path} />
   }
 
-  switch (baseContentType) {
-    case 'image/png': {
+  // Extract main and sub types
+  const [mainType, subType] = mimeType.split('/')
+
+  // Group by main MIME type
+  switch (mainType) {
+    case 'image': {
+      // Handle all image types with FileImage renderer
       const blob = await res.blob()
       const objectURL = URL.createObjectURL(blob)
-      return <FilePNG url={objectURL} />
+      return <FileImage url={objectURL} />
     }
-    case 'application/pdf': {
-      const arrayBuffer = await res.arrayBuffer()
-      const pdfData = new Uint8Array(arrayBuffer)
-      return <FilePDF pdfData={pdfData} />
+    case 'application': {
+      if (subType === 'pdf') {
+        const arrayBuffer = await res.arrayBuffer()
+        const pdfData = new Uint8Array(arrayBuffer)
+        return <FilePDF pdfData={pdfData} />
+      }
+      // Fall through to default for unhandled application types
+      break
     }
-    default: {
-      console.error(
-        `Rendering ${contentType.split(';')[0]} not supported by filesystem`
-      )
-      return <p>{`${contentType.split(';')[0]} not supported by filesystem`}</p>
-    }
+    // Add cases for video and audio if needed in the future
   }
+
+  // Default case for unhandled types
+  console.error(`Rendering ${mimeType} not supported by filesystem`)
+  return <p>{`${mimeType} not supported by filesystem`}</p>
 }
 
 export default function FileSystem({ id, path }: FileSystemProps): JSX.Element {

--- a/ui/src/components/renderers/FileSystem.tsx
+++ b/ui/src/components/renderers/FileSystem.tsx
@@ -4,6 +4,8 @@ import { get, put } from '../../api/sky'
 import FileImage from './FileImage'
 import FileComposer from './FileComposer'
 import FilePDF from './FilePDF'
+import FileVideo from './FileVideo'
+import FileAudio from './FileAudio'
 
 interface FileSystemProps {
   id: number
@@ -48,6 +50,18 @@ async function renderFile(path: string, res: Response): Promise<JSX.Element> {
       const objectURL = URL.createObjectURL(blob)
       return <FileImage url={objectURL} />
     }
+    case 'video': {
+      // Handle all video types with FileVideo renderer
+      const blob = await res.blob()
+      const objectURL = URL.createObjectURL(blob)
+      return <FileVideo url={objectURL} />
+    }
+    case 'audio': {
+      // Handle all audio types with FileAudio renderer
+      const blob = await res.blob()
+      const objectURL = URL.createObjectURL(blob)
+      return <FileAudio url={objectURL} />
+    }
     case 'application': {
       if (subType === 'pdf') {
         const arrayBuffer = await res.arrayBuffer()
@@ -57,7 +71,6 @@ async function renderFile(path: string, res: Response): Promise<JSX.Element> {
       // Fall through to default for unhandled application types
       break
     }
-    // Add cases for video and audio if needed in the future
   }
 
   // Default case for unhandled types

--- a/ui/src/components/renderers/FileSystem.tsx
+++ b/ui/src/components/renderers/FileSystem.tsx
@@ -128,7 +128,6 @@ export default function FileSystem({ id, path }: FileSystemProps): JSX.Element {
       <button onClick={handleUploadClick}>Upload a file</button>
       <input
         type="file"
-        accept=".css, .html, .js, .json, .md, .pdf, .png, .txt, .xml"
         style={{ display: 'none' }}
         onChange={uploadFiles}
       />

--- a/ui/src/components/renderers/FileVideo.tsx
+++ b/ui/src/components/renderers/FileVideo.tsx
@@ -1,0 +1,11 @@
+interface FileVideoProps {
+  url: string
+}
+
+export default function FileVideo({ url }: FileVideoProps): JSX.Element {
+  return (
+    <div className="hf wf fc ac jc p2">
+      <video src={url} controls style={{ maxWidth: '100%', maxHeight: '100%' }} />
+    </div>
+  )
+}

--- a/ui/src/components/renderers/Image.tsx
+++ b/ui/src/components/renderers/Image.tsx
@@ -1,12 +1,12 @@
-interface ImagePNGProps {
+interface ImageProps {
   url: string
 }
 
-export default function ImagePNG({ url }: ImagePNGProps): JSX.Element {
+export default function Image({ url }: ImageProps): JSX.Element {
   return (
     <img
       src={url}
-      alt="PNG image"
+      alt="image"
       className="hf wf"
       style={{ objectFit: 'cover' }}
     />

--- a/ui/src/components/renderers/Video.tsx
+++ b/ui/src/components/renderers/Video.tsx
@@ -1,0 +1,13 @@
+interface VideoProps {
+  url: string
+}
+
+export default function Video({ url }: VideoProps): JSX.Element {
+  return (
+    <video
+      src={url}
+      controls
+      className="hf wf"
+    />
+  )
+}


### PR DESCRIPTION
Automatically construct MIMEs when they're received in %seer so we don't have to do mark conversions; using mark conversions at all was a hangover from how the %sky agent handled these before I switched from storing files in Clay to Gall.